### PR TITLE
Level up system and stats increase on level up

### DIFF
--- a/Project/Assets/Scripts/Manager/PlayerManager.cs
+++ b/Project/Assets/Scripts/Manager/PlayerManager.cs
@@ -27,13 +27,16 @@ public class PlayerManager : MonoBehaviour
 
     #region Events
 
-
+    public event EventHandler OnLevelChanged;
+    public event EventHandler OnExpChanged;
+    
     #endregion
 
     #region Initializations
 
     public CharacterStats playerStats;
     public StatusBar healthBar;
+    public StatusBar expBar; //needs to be assigned
 
     public Button attackButton;
     public AttackDefenition baseAttack;
@@ -47,12 +50,17 @@ public class PlayerManager : MonoBehaviour
     {
         playerStats = GetComponent<CharacterStats>();
         projectileManager = GetComponent<ProjectileManager>();
+        
+        //Initialize the two events with their method
+        OnLevelChanged += OnLevelChange;
+        OnExpChanged += OnExpChange;
 
         //onTakingDamage += TakingDamage;
         //onHealing += IncreasingHealth;
 
         UpdateHealthSlider();
     }
+    
 
     // Update is called once per frame
     void Update()
@@ -62,6 +70,14 @@ public class PlayerManager : MonoBehaviour
             playerStats.TakeDamage(10);
             UpdateHealthSlider();
         }
+
+        if (Input.GetKeyDown(KeyCode.L)) //Debug purposes, can be removed at any time
+        {
+            GiveExp(40);
+            Debug.Log($"Actual level:{playerStats.GetLevel()} \n Actual Exp:{playerStats.GetActualExp()}   Actual Max EXP:{playerStats.GetMaxExp()}");
+            //Remember to delete the Debug.log in the OnLevelChange() method when you are not longer going to use this debug tool.
+        }
+        
     }
 
     #endregion
@@ -79,10 +95,11 @@ public class PlayerManager : MonoBehaviour
     {
 
     }
-    
+
     public void UpdateExpSlider()
     {
-
+       // expBar.UpdateSlider((float)playerStats.GetActualExp() / (float)playerStats.GetMaxExp());
+       // remove the "//" after having the slider assigned
     }
 
     #endregion
@@ -101,6 +118,12 @@ public class PlayerManager : MonoBehaviour
     {
         playerStats.GiveCredit(amount);
     }
+
+    public void GiveExp(int amount)
+    {
+        playerStats.GiveExp(amount);
+    }
+    
     #endregion
 
 
@@ -130,6 +153,34 @@ public class PlayerManager : MonoBehaviour
         {
             e.OnAttack(gameObject, attack);
         }
+    }
+
+    #endregion
+
+    #region Event Calls
+
+    public void LevelUpEventCall()
+    {
+        OnLevelChanged?.Invoke(this,EventArgs.Empty);
+    }
+
+    public void ExpChangeEventCall()
+    {
+        OnExpChanged?.Invoke(this, EventArgs.Empty);
+    }
+    
+    private void OnLevelChange(object sender, EventArgs e) //Method called onlevelchanged event
+    {
+        //Visual effects or things that happen on the event of leveling up
+        playerStats.IncreaseStats();
+        UpdateExpSlider();
+        Debug.Log($"LEVEL UP! \n New Stats:  MAXHEALTH = {playerStats.stats.maxHealth} MAXSHIELD = {playerStats.stats.maxShield} BASEARMOR = {playerStats.stats.baseArmor}  "); //Debug purposes, can be removed at any time
+    }
+
+    private void OnExpChange(object sender, EventArgs e) //Method called onexpchanged event
+    {
+        //Visual effects or things that happen on the event of getting exp
+        UpdateExpSlider();
     }
 
     #endregion

--- a/Project/Assets/Scripts/Manager/PlayerManager.cs
+++ b/Project/Assets/Scripts/Manager/PlayerManager.cs
@@ -184,4 +184,13 @@ public class PlayerManager : MonoBehaviour
     }
 
     #endregion
+
+    #region Save 
+
+    public void SaveStats()
+    {
+        playerStats.SaveStats();
+    }
+
+    #endregion
 }

--- a/Project/Assets/Scripts/Stats/CharacterStats.cs
+++ b/Project/Assets/Scripts/Stats/CharacterStats.cs
@@ -12,11 +12,13 @@ public class CharacterStats : MonoBehaviour
 
     private void Start()
     {
+        LoadStats();
         if(stats_Template != null)
         {
             stats = Instantiate(stats_Template);
         }
     }
+
     #region Increasers
     public void GiveHealth(int amount)
     {
@@ -107,5 +109,19 @@ public class CharacterStats : MonoBehaviour
     {
         return stats.maxExp;
     }
+    #endregion
+
+    #region Save and Load
+
+    public void SaveStats()
+    {
+        stats.SaveStats();
+    }
+
+    public void LoadStats()
+    {
+        stats_Template.LoadStats();
+    }
+    
     #endregion
 }

--- a/Project/Assets/Scripts/Stats/CharacterStats.cs
+++ b/Project/Assets/Scripts/Stats/CharacterStats.cs
@@ -30,6 +30,17 @@ public class CharacterStats : MonoBehaviour
     {
         stats.GiveCredit(amount);
     }
+
+    public void GiveExp(int amount)
+    {
+        stats.GiveExp(amount);
+    }
+
+    public void IncreaseStats()
+    {
+        stats.IncreaseStats();
+    }
+
     #endregion
 
     #region Decreasers
@@ -80,6 +91,21 @@ public class CharacterStats : MonoBehaviour
     public float GetCriticalChance()
     {
         return stats.criticalChance;
+    }
+
+    public int GetLevel()
+    {
+        return stats.level;
+    }
+
+    public int GetActualExp()
+    {
+        return stats.currentExp;
+    }
+
+    public int GetMaxExp()
+    {
+        return stats.maxExp;
     }
     #endregion
 }

--- a/Project/Assets/Scripts/Stats/CharacterStats_SO.cs
+++ b/Project/Assets/Scripts/Stats/CharacterStats_SO.cs
@@ -123,4 +123,37 @@ public class CharacterStats_SO : ScriptableObject
         currentCredit -= amount;
     }
     #endregion
+
+    #region Save and Load
+
+    public void LoadStats()
+    {
+        if (PlayerPrefs.HasKey("Level"))
+        {
+            level = PlayerPrefs.GetInt("Level");
+            maxShield = PlayerPrefs.GetInt("MaxShield");
+            maxHealth = PlayerPrefs.GetInt("MaxHealth");
+            maxExp = PlayerPrefs.GetInt("MaxExp");
+            currentExp = PlayerPrefs.GetInt("CurrentExp");
+            currentCredit = PlayerPrefs.GetInt("Credits");
+            baseArmor = PlayerPrefs.GetInt("BaseArmor");
+            criticalChance = PlayerPrefs.GetFloat("CriticalChance");
+            baseDamage = PlayerPrefs.GetInt("BaseDamage");
+        }
+    }
+
+    public void SaveStats()
+    {
+        PlayerPrefs.SetInt("Level",level);
+        PlayerPrefs.SetInt("MaxShield",maxShield);
+        PlayerPrefs.SetInt("MaxHealth",maxHealth);
+        PlayerPrefs.SetInt("MaxExp",maxExp);
+        PlayerPrefs.SetInt("CurrentExp",currentExp);
+        PlayerPrefs.SetInt("Credits",currentCredit);
+        PlayerPrefs.SetInt("BaseArmor",baseArmor);
+        PlayerPrefs.SetFloat("CriticalChance",criticalChance);
+        PlayerPrefs.SetInt("BaseDamage",baseDamage);
+    }
+
+    #endregion
 }

--- a/Project/Assets/Scripts/Stats/CharacterStats_SO.cs
+++ b/Project/Assets/Scripts/Stats/CharacterStats_SO.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -11,6 +12,7 @@ public class CharacterStats_SO : ScriptableObject
     public int level = 1;
     public int currentExp = 0;
     public int maxExp = 100;
+    public float expMaxlvlMultiplier = 1.25f; //how much the maxExp will increase on each level
 
 
     public int maxHealth;
@@ -56,6 +58,34 @@ public class CharacterStats_SO : ScriptableObject
     {
         currentCredit += amount;
     }
+
+    public void GiveExp(int amount)
+    {
+        currentExp += amount;
+        if (currentExp >= maxExp)
+        {
+            while (currentExp >= maxExp) //level up
+            {
+                level++;
+                currentExp -= maxExp;
+                maxExp = (int) (maxExp * expMaxlvlMultiplier);
+                PlayerManager.instance.LevelUpEventCall();
+            }
+        }else
+        {
+            PlayerManager.instance.ExpChangeEventCall();
+        }
+    }
+
+    public void IncreaseStats() //method that will be called on level up
+    {
+        //temporal values
+        maxHealth += 10;
+        maxShield += 8;
+        baseArmor += 3;
+    }
+    
+    
     #endregion
 
     #region Decreasers


### PR DESCRIPTION
Created 2 events, one for LevelUp and the other one for ExpChange, both of them connected to the update slider (which needs to be assigned when ready).

Player currently increases max health, max shield and base armor on level up.

If you press L key ingame you can debug the level system and the stats increase on level up.